### PR TITLE
chore(ci/flatpak): Freedesktop runtime + python3 extension; add smoke test; pre-commit cleanups and noise reduction

### DIFF
--- a/.github/workflows/flatpak-clipboard-bridge.yml
+++ b/.github/workflows/flatpak-clipboard-bridge.yml
@@ -28,17 +28,23 @@ jobs:
       - name: Install Flatpak and flatpak-builder
         timeout-minutes: 10
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq flatpak flatpak-builder python3-pip jq curl
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y flathub org.freedesktop.Sdk//23.08 org.freedesktop.Platform//23.08 org.freedesktop.Sdk.Extension.python3//23.08
+          set -euo pipefail
+          sudo apt-get -yq update
+          sudo apt-get -yq install -o=Dpkg::Use-Pty=0 --no-install-recommends flatpak flatpak-builder jq curl
+          flatpak --system remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || true
+          flatpak --user   remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || true
 
       - name: Build Flatpak
         working-directory: flatpak/clipboard-bridge
         timeout-minutes: 12
+        env:
+          FLATPAK_USER_DIR: ${{ runner.temp }}/flatpak-user
         run: |
+          set -euo pipefail
+          mkdir -p "$FLATPAK_USER_DIR"
+          flatpak --user update --appstream || true
           rm -rf build repo
-          flatpak-builder --force-clean --repo=repo build org.overlaycompanion.ClipboardBridge.yml
+          flatpak-builder --user --install-deps-from=flathub --force-clean --repo=repo build org.overlaycompanion.ClipboardBridge.yml
 
       - name: Export bundle
         working-directory: flatpak/clipboard-bridge
@@ -59,6 +65,8 @@ jobs:
         if: ${{ github.event_name != 'release' }}
         timeout-minutes: 6
         working-directory: flatpak/clipboard-bridge
+        env:
+          FLATPAK_USER_DIR: ${{ runner.temp }}/flatpak-user
         run: |
           set -euo pipefail
           APP_ID=org.overlaycompanion.ClipboardBridge
@@ -66,7 +74,7 @@ jobs:
 
           echo "Installing bundle..."
           flatpak --user uninstall -y $APP_ID || true
-          flatpak --user install -y $BUNDLE
+          flatpak --user install -y --noninteractive $BUNDLE
 
           echo "Launching service..."
           flatpak --user run --command=clipboard-bridge $APP_ID > bridge.log 2>&1 &
@@ -76,7 +84,7 @@ jobs:
           attempt=0
           until curl -sSf http://127.0.0.1:8765/health | jq -e '.status=="healthy"' >/dev/null 2>&1; do
             attempt=$((attempt+1))
-            if [ $attempt -gt 20 ]; then
+            if [ $attempt -gt 40 ]; then
               echo "Health check failed" >&2
               echo "--- bridge.log ---"; tail -n 200 bridge.log || true; echo "---------------"
               exit 1

--- a/.github/workflows/flatpak-clipboard-bridge.yml
+++ b/.github/workflows/flatpak-clipboard-bridge.yml
@@ -29,8 +29,11 @@ jobs:
         timeout-minutes: 10
         run: |
           set -euo pipefail
-          sudo apt-get -yq update
-          sudo apt-get -yq install -o=Dpkg::Use-Pty=0 --no-install-recommends flatpak flatpak-builder jq curl
+          export DEBIAN_FRONTEND=noninteractive
+          echo "Installing flatpak and flatpak-builder (quiet)..."
+          sudo apt-get -yqq update > apt-update.log 2>&1 || { echo "apt update failed"; tail -n 200 apt-update.log; exit 1; }
+          sudo apt-get -yqq install -o=Dpkg::Use-Pty=0 --no-install-recommends flatpak flatpak-builder jq curl > apt-install.log 2>&1 || { echo "apt install failed"; tail -n 200 apt-install.log; exit 1; }
+          echo "Configuring Flathub remotes..."
           flatpak --system remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || true
           flatpak --user   remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || true
 


### PR DESCRIPTION
# Pull Request

## Description
This PR keeps the Flatpak app on Freedesktop 23.08 with the python3 extension, adds a CI smoke test that runs the headless clipboard bridge service and polls `/health`, and ensures pre-commit passes cleanly across the repo while reducing CI noise.

## Type of Change
- [x] CI enhancement
- [x] Documentation update
- [x] Test coverage improvement (smoke test)
- [x] Chore / Cleanups

## Changes Made
- Flatpak manifest remains Freedesktop runtime (org.freedesktop.Platform//23.08) with org.freedesktop.Sdk.Extension.python3
- Workflow `.github/workflows/flatpak-clipboard-bridge.yml`:
  - Use user-scoped Flatpak (`FLATPAK_USER_DIR`) and resilient Flathub remotes (system and user) pointing to dl.flathub.org
  - Let `flatpak-builder` resolve/install dependencies via `--install-deps-from=flathub` (avoids transient extension availability failures)
  - Add smoke test: install bundle, run `clipboard-bridge` (headless), poll `/health`, and shutdown, with bounded retries
  - Reduce apt noise by redirecting to logs; tail on failure
- Pre-commit:
  - Bandit scoped to product code (flatpak/clipboard-bridge) at medium severity/confidence; tests no longer block on bandit
  - dotnet-format skips gracefully if `dotnet` is not present
  - Detect-secrets allowlist on non-sensitive documentation examples; markdownlint list numbering corrected
  - Flake8, black, isort clean across modified files
- Minor fixes:
  - Normalize tests/ headers/imports
  - Remove unused imports
  - YAML: fix tabs/indentation in `infra/podman-compose.yml`

## MCP Specification Impact
- [x] No changes to MCP specification

## Testing
- [x] Pre-commit `--all-files` passes
- [x] Flatpak workflow builds bundle and smoke tests the service

## Documentation
- [x] Updated docs with allowlist pragmas where examples include passwords/API keys

## Checklist
- [x] Follows project coding standards
- [x] Self-reviewed
- [x] No new warnings introduced

## Privacy and Security
- [x] No new privacy concerns
- [x] No new security vulnerabilities introduced

## Performance Impact
- [x] No performance impact

## Breaking Changes
- [x] No breaking changes

## Additional Notes
- PR intentionally left in draft until you mark it ready

Co-authored-by: openhands <openhands@all-hands.dev>

@RyansOpenSourceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a0bf5794ff294f5ebca7eda3fdb02fdc)