### PR TITLE
test(smoke): add/repair infra/local_smoke_test.sh (auto-port selection + .env support)

### DIFF
--- a/infra/local_smoke_test.sh
+++ b/infra/local_smoke_test.sh
@@ -1,17 +1,89 @@
 #!/usr/bin/env bash
 
+# local_smoke_test.sh
+# Lightweight smoke-test runner that:
+#  - pulls required images
+#  - runs containers with explicit docker run commands on a user bridge network
+#  - auto-selects free host ports when not provided (avoids port collisions)
+#  - prints recent logs to stdout for easy copy/paste
+#  - clears persistent named volumes while preserving container objects so tests can be repeated
+#
+# Usage:
+#   chmod +x infra/local_smoke_test.sh
+#   ./infra/local_smoke_test.sh start
+#   ./infra/local_smoke_test.sh logs
+#   ./infra/local_smoke_test.sh clear-data
+#
+# Notes:
+#  - If docker pull returns "denied" for ghcr.io images, run:
+#      echo "YOUR_GHCR_PAT" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+#    The script will continue even if some pulls fail so you can capture logs.
+
+# Load environment overrides from .env.smoke or .env in repository root (optional)
+ENV_FILE=".env.smoke"
+if [ -f "$ENV_FILE" ]; then
+  echo "Loading environment from $ENV_FILE"
+  # shellcheck disable=SC1090
+  set +u; set -o allexport; source "$ENV_FILE"; set +o allexport; set -u
+elif [ -f .env ]; then
+  echo "Loading environment from .env"
+  set +u; set -o allexport; source .env; set +o allexport; set -u
+fi
+
 set -euo pipefail
 
 # Config
 NETWORK_NAME="overlay-smoke-net"
 VOLS=(kasmvnc_data kasmvnc_profiles)
-IMAGES=( \
-  "lscr.io/linuxserver/kasm:latest" \
-  "ghcr.io/ryansopensaucerice/overlay-companion-mcp/mcp-server:2025.09.12.2" \
-  "ghcr.io/ryansopensaucerice/overlay-companion-mcp/web-interface:2025.09.12.2" \
-  "docker.io/library/caddy:2.8.4" \
+IMAGES=(
+  "lscr.io/linuxserver/kasm:latest"
+  "ghcr.io/ryansopensaucerice/overlay-companion-mcp/mcp-server:2025.09.12.2"
+  "ghcr.io/ryansopensaucerice/overlay-companion-mcp/web-interface:2025.09.12.2"
+  "docker.io/library/caddy:2.8.4"
 )
 
+# Container names (stable)
+CN_KASM="overlay-companion-kasmvnc"
+CN_MCP="overlay-companion-mcp"
+CN_WEB="overlay-companion-web"
+CN_CADDY="overlay-companion-proxy"
+
+# Helper: pick an available ephemeral port on the host
+pick_free_port() {
+  python3 - <<'PY'
+import socket
+s=socket.socket()
+s.bind(('127.0.0.1',0))
+port=s.getsockname()[1]
+s.close()
+print(port)
+PY
+}
+
+# Ports mapped to host - honor environment variables when provided, otherwise auto-pick free ports
+PORT_KASM=${KASMVNC_PORT:-}
+PORT_KASM_ADMIN=${KASMVNC_ADMIN_PORT:-}
+PORT_MCP=${MCP_PORT:-}
+PORT_WEB=${WEB_PORT:-}
+PORT_CADDY=${CONTAINER_PORT:-}
+
+if [ -z "${PORT_KASM}" ]; then
+  PORT_KASM=$(pick_free_port)
+fi
+if [ -z "${PORT_KASM_ADMIN}" ]; then
+  PORT_KASM_ADMIN=$(pick_free_port)
+fi
+if [ -z "${PORT_MCP}" ]; then
+  PORT_MCP=$(pick_free_port)
+fi
+if [ -z "${PORT_WEB}" ]; then
+  PORT_WEB=$(pick_free_port)
+fi
+if [ -z "${PORT_CADDY}" ]; then
+  PORT_CADDY=$(pick_free_port)
+fi
+
+echo "Selected host ports: KASMVNC=${PORT_KASM}, KASMVNC_ADMIN=${PORT_KASM_ADMIN}, MCP=${PORT_MCP}, WEB=${PORT_WEB}, CADDY=${PORT_CADDY}"
 
 # Pull required images
 pull_images() {
@@ -45,7 +117,7 @@ start_containers() {
     -v kasmvnc_data:/opt -v kasmvnc_profiles:/profiles -v /dev/input:/dev/input:ro -v /run/udev/data:/run/udev/data:ro \
     -p ${PORT_KASM}:6901 -p ${PORT_KASM_ADMIN}:3000 \
     --restart unless-stopped \
-    "${IMAGES[0]}"
+    "${IMAGES[0]}" || echo "Failed starting $CN_KASM"
 
   # Start mcp server
   docker run -d \
@@ -54,7 +126,7 @@ start_containers() {
     -e ASPNETCORE_URLS=http://0.0.0.0:3000 -e KASMVNC_URL=http://$CN_KASM:6901 \
     -p ${PORT_MCP}:3000 \
     --restart unless-stopped \
-    "${IMAGES[1]}"
+    "${IMAGES[1]}" || echo "Failed starting $CN_MCP"
 
   # Start web interface
   docker run -d \
@@ -63,9 +135,9 @@ start_containers() {
     -e PORT=8080 -e MCP_SERVER_URL=http://$CN_MCP:3000 -e KASMVNC_URL=http://$CN_KASM:6901 \
     -p ${PORT_WEB}:8080 \
     --restart unless-stopped \
-    "${IMAGES[2]}"
+    "${IMAGES[2]}" || echo "Failed starting $CN_WEB"
 
-  # Start caddy (optional: requires local Caddyfile.kasmvnc present if you want custom config)
+  # Start caddy (optional)
   if [ -f ./Caddyfile.kasmvnc ]; then
     docker run -d \
       --name "$CN_CADDY" \
@@ -73,12 +145,12 @@ start_containers() {
       -p ${PORT_CADDY}:80 \
       -v "$(pwd)/Caddyfile.kasmvnc":/etc/caddy/Caddyfile:ro \
       --restart unless-stopped \
-      "${IMAGES[3]}"
+      "${IMAGES[3]}" || echo "Failed starting $CN_CADDY"
   else
     echo "Note: ./Caddyfile.kasmvnc not found; skipping caddy container (you can add it later)."
   fi
 
-  echo "Containers started. Give services a few seconds to warm up."
+  echo "Containers started (or attempted). Give services a few seconds to warm up."
 }
 
 # Quick tests
@@ -94,16 +166,15 @@ test_endpoints() {
   curl -I --max-time 5 "http://localhost:${PORT_KASM}/" || true
 }
 
-# Collect logs into infra/logs/
-collect_logs() {
-  mkdir -p infra/logs
+# Print logs to stdout for easy copy/paste
+print_logs() {
   for c in "$CN_MCP" "$CN_WEB" "$CN_KASM" "$CN_CADDY"; do
     if docker ps -a --format '{{.Names}}' | grep -q "^${c}$"; then
-      echo "Collecting logs for $c -> infra/logs/${c}.log"
-      docker logs "$c" > "infra/logs/${c}.log" 2>&1 || true
+      echo "\n===== LOGS: ${c} ====="
+      docker logs --tail 400 "$c" 2>&1 || true
+      echo "===== END LOGS: ${c} =====\n"
     fi
   done
-  echo "Logs saved to infra/logs/"
 }
 
 # Clear the data inside named volumes but do NOT remove the container objects
@@ -111,7 +182,6 @@ clear_data_keep_containers() {
   echo "Clearing data from named volumes: ${VOLS[*]} (keeps containers)"
   for v in "${VOLS[@]}"; do
     echo "Clearing volume: $v"
-    # Use a short-lived container to mount and remove files from the volume.
     docker run --rm -v "${v}:/data" busybox sh -c 'rm -rf /data/* || true; sync'
   done
   echo "Volume data cleared. Note: containers still exist but may have lost state."
@@ -144,7 +214,7 @@ status() {
   docker volume ls --filter name=kasmvnc -q || true
 }
 
-# Interactive loop to run -> test -> collect logs -> clear data -> repeat
+# Interactive loop to run -> test -> print logs -> clear data -> repeat
 run_loop() {
   echo "Starting interactive run loop. Press Ctrl-C to exit at any time."
   while true; do
@@ -158,9 +228,9 @@ run_loop() {
     echo "\n=== Run quick tests (inspect and copy errors) ==="
     test_endpoints
 
-    echo "\nWhen you've finished manual testing, press ENTER to collect logs."
+    echo "\nWhen you've finished manual testing, press ENTER to print logs to the terminal (copy/paste the error blobs)."
     read -r
-    collect_logs
+    print_logs
 
     echo "\nPress ENTER to clear persistent data (keeps container objects)."
     read -r
@@ -185,8 +255,8 @@ case "${1:-}" in
   test)
     test_endpoints
     ;;
-  collect-logs)
-    collect_logs
+  logs)
+    print_logs
     ;;
   clear-data)
     stop_containers
@@ -211,12 +281,12 @@ Usage: $0 <command>
 Commands:
   start         Pull images and start containers (detached)
   test          Run quick HTTP HEAD tests against services
-  collect-logs  Save container logs to infra/logs/
+  logs          Print recent container logs to stdout for copy/paste
   clear-data    Clear named volume data (keeps container objects)
   stop          Stop containers (keeps container objects)
   remove        Remove container objects entirely
   status        Show container + volume status
-  run-loop      Interactive sequence: start -> test -> collect -> clear -> repeat
+  run-loop      Interactive sequence: start -> test -> print logs -> clear -> repeat
 EOF
     exit 1
     ;;


### PR DESCRIPTION
## Description

This PR adds a local smoke-test helper script (infra/local_smoke_test.sh) and repairs a corrupted edit. The script:
- pulls required container images
- runs containers with explicit `docker run` commands on a user bridge network
- auto-selects free host ports when not provided and supports `.env.smoke` / `.env` overrides
- prints recent logs to stdout for easy copy/paste
- clears named volumes while keeping container objects to allow rapid iterative testing

This PR contains only test/infra tooling and does not change production code.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (inline usage notes in script)

## Changes Made

- Added infra/local_smoke_test.sh (script to run and test containers locally)
- Repaired earlier accidental removal of container name and port variable declarations

## MCP Specification Impact

- [x] No changes to MCP specification

## Testing

- [x] Script was run locally in the development environment to validate startup and logging behavior
- [ ] I have not added unit tests (script is a developer helper)

## Documentation

- Inline usage notes added at top of infra/local_smoke_test.sh describing commands and authentication guidance for GHCR.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (no tests were modified)

## Privacy and Security

- [x] This change does not introduce new privacy concerns
- [x] This change does not introduce new security vulnerabilities

## Additional Notes

- If GHCR anonymous pulls are denied on some hosts, run `echo "YOUR_GHCR_PAT" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin` before using the script.

## Related Issues

None
